### PR TITLE
Remove automatic challenge request on startup.

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', function() {
     submitBtn.addEventListener('click', submitSolution);
 
     // Load initial challenge
-    loadNewChallenge();
+    // loadNewChallenge();
 
     // Language Change Handler
     function handleLanguageChange() {


### PR DESCRIPTION
This change disables the automatic loading of a coding challenge when the web application starts. The challenge will now only be requested when the user explicitly clicks the 'New Challenge' button.

Manual verification was performed as the test environment is unavailable.